### PR TITLE
Fix failure on new msg

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reshuffle-imap-connector",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A Reshuffle IMAP connector",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
- remove unused event option name in on method
- mailbox is now an event options so you can get the event configuration matching with mailbox (can now listen to many mailbox within the same connection)
on new message, the event is passed to the handler, with mail object being under `event.context`

